### PR TITLE
Restrict guest access and add invite-code signup system

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ function App() {
   const [signupUsername, setSignupUsername] = useState('')
   const [signupPassword, setSignupPassword] = useState('')
   const [signupName, setSignupName] = useState('')
+  const [signupInviteCode, setSignupInviteCode] = useState('')
   
   // Session state
   const [sessionId, setSessionId] = useState(null)
@@ -165,7 +166,7 @@ function App() {
   }
 
   const signup = async () => {
-    if (!signupUsername.trim() || !signupPassword.trim() || !signupName.trim()) {
+    if (!signupUsername.trim() || !signupPassword.trim() || !signupName.trim() || !signupInviteCode.trim()) {
       showMessage('Please fill in all fields', 'error')
       return
     }
@@ -188,7 +189,8 @@ function App() {
         body: JSON.stringify({
           username: signupUsername.trim(),
           password: signupPassword.trim(),
-          name: signupName.trim()
+          name: signupName.trim(),
+          invite_code: signupInviteCode.trim()
         })
       })
 
@@ -198,6 +200,7 @@ function App() {
         setSignupUsername('')
         setSignupPassword('')
         setSignupName('')
+        setSignupInviteCode('')
         setShowSignupDialog(false)
       } else {
         showMessage(data.error || 'Signup failed', 'error')
@@ -310,7 +313,11 @@ function App() {
       const response = await fetch(`${API_BASE}/session/list`)
       if (response.ok) {
         const data = await response.json()
-        setSessions(data.sessions || [])
+        let sessionList = data.sessions || []
+        if (user?.role === 'guest') {
+          sessionList = sessionList.filter(s => s.is_public)
+        }
+        setSessions(sessionList)
       }
     } catch (error) {
       console.error('Failed to load sessions:', error)
@@ -634,6 +641,20 @@ function App() {
     }
   }
 
+  const generateInviteCode = async () => {
+    try {
+      const response = await fetch(`${API_BASE}/admin/invite`, { method: 'POST' })
+      const data = await response.json()
+      if (response.ok) {
+        showMessage(`Invite code: ${data.invite_code}`, 'success')
+      } else {
+        showMessage(data.error || 'Failed to generate invite code', 'error')
+      }
+    } catch (error) {
+      showMessage('Failed to generate invite code', 'error')
+    }
+  }
+
   // Super admin functions
   const changeUserRole = async (username, newRole) => {
     try {
@@ -818,6 +839,16 @@ function App() {
                   placeholder="Choose a password (min 6 characters)"
                   value={signupPassword}
                   onChange={(e) => setSignupPassword(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="signup-invite">Invite Code</Label>
+                <Input
+                  id="signup-invite"
+                  type="text"
+                  placeholder="Enter invite code"
+                  value={signupInviteCode}
+                  onChange={(e) => setSignupInviteCode(e.target.value)}
                 />
               </div>
               <div className="flex gap-2">
@@ -1011,23 +1042,25 @@ function App() {
           </Card>
 
           {/* Export Records */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Download className="h-5 w-5" />
-                Export Food Waste Data
-              </CardTitle>
-              <CardDescription>
-                Download plate cleanliness records by category (Clean, Dirty, Very Dirty)
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Button onClick={exportCSV} className="w-full bg-amber-600 hover:bg-amber-700">
-                <Download className="h-4 w-4 mr-2" />
-                Export Food Waste Data
-              </Button>
-            </CardContent>
-          </Card>
+          {user?.role !== 'guest' && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Download className="h-5 w-5" />
+                  Export Food Waste Data
+                </CardTitle>
+                <CardDescription>
+                  Download plate cleanliness records by category (Clean, Dirty, Very Dirty)
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button onClick={exportCSV} className="w-full bg-amber-600 hover:bg-amber-700">
+                  <Download className="h-4 w-4 mr-2" />
+                  Export Food Waste Data
+                </Button>
+              </CardContent>
+            </Card>
+          )}
         </div>
 
         {/* Category Recording Buttons */}
@@ -1343,19 +1376,29 @@ function App() {
             </DialogHeader>
             <div className="space-y-6">
               <div className="flex gap-4">
-                {user.role === 'admin' || user.role === 'superadmin' ? (
-                  <Button 
-                    onClick={() => {
-                      setShowDeleteRequests(true)
-                      loadDeleteRequests()
-                    }}
-                    variant="outline"
-                    className="flex-1"
-                  >
-                    <Trash2 className="h-4 w-4 mr-2" />
-                    Delete Requests ({deleteRequests.length})
-                  </Button>
-                ) : null}
+                {['admin', 'superadmin'].includes(user.role) && (
+                  <>
+                    <Button
+                      onClick={generateInviteCode}
+                      variant="outline"
+                      className="flex-1"
+                    >
+                      <UserPlus className="h-4 w-4 mr-2" />
+                      Generate Invite Code
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        setShowDeleteRequests(true)
+                        loadDeleteRequests()
+                      }}
+                      variant="outline"
+                      className="flex-1"
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      Delete Requests ({deleteRequests.length})
+                    </Button>
+                  </>
+                )}
               </div>
 
               <div>


### PR DESCRIPTION
## Summary
- add `is_public` flag to sessions and filter guest lists/switching
- require authentication for CSV export
- hide export UI and filter sessions in frontend for guests
- require one-time invite codes for signup and let admins generate them

## Testing
- `npm test` (fails: Missing script "test")
- `npm test` in frontend (fails: Missing script "test")
- `npm run lint` in frontend (fails: Cannot find module 'eslint')
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c19cccc4188320ad87ba329fce3153