### PR TITLE
Improve session privacy and popups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ MarkupSafe==3.0.2
 SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 Werkzeug==3.1.3
+pytest==8.3.3
 

--- a/tests/test_student_security.py
+++ b/tests/test_student_security.py
@@ -1,0 +1,53 @@
+import io
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from src.main import app
+
+
+def login(client, username='admin', password='admin123'):
+    return client.post('/api/auth/login', json={'username': username, 'password': password})
+
+
+def upload_sample_csv(client):
+    csv_content = 'Last,First,Student ID\nDoe,John,12345\n'
+    data = {
+        'file': (io.BytesIO(csv_content.encode('utf-8')), 'students.csv')
+    }
+    return client.post('/api/csv/upload', data=data, content_type='multipart/form-data')
+
+
+def test_records_store_only_names_and_csv_cleared_on_logout():
+    with app.test_client() as client:
+        # Login and upload CSV
+        resp = login(client)
+        assert resp.status_code == 200
+        assert upload_sample_csv(client).status_code == 200
+
+        # Create a session
+        client.post('/api/session/create', json={'session_name': 'Test'})
+
+        # Record student by ID
+        record_resp = client.post('/api/record/clean', json={'input_value': '12345'})
+        assert record_resp.status_code == 200
+
+        # Ensure record history contains name only
+        history_resp = client.get('/api/session/history')
+        data = history_resp.get_json()
+        assert history_resp.status_code == 200
+        assert 'scan_history' in data
+        assert data['scan_history'][0]['first_name'] == 'John'
+        assert 'Student ID' not in data['scan_history'][0]
+
+        # Logout to clear CSV data
+        client.post('/api/auth/logout')
+
+        # Login again and ensure CSV preview shows no data
+        login(client)
+        preview_resp = client.get('/api/csv/preview')
+        preview_data = preview_resp.get_json()
+        assert preview_resp.status_code == 200
+        assert preview_data['status'] == 'no_data'
+


### PR DESCRIPTION
## Summary
- avoid persisting uploaded CSV data and record only student names
- implement HTML pop-ups with copyable invite codes and scrollable admin panel
- add unit test ensuring CSV data is cleared on logout

## Testing
- `pytest`
- `npm --prefix frontend run lint` *(fails: no-unused-vars and other ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c49bf8753c8320a15627dccdba69a2