### PR TITLE
Improve session privacy and popups

### DIFF
--- a/frontend/src/components/NotificationProvider.jsx
+++ b/frontend/src/components/NotificationProvider.jsx
@@ -1,0 +1,72 @@
+import React, { createContext, useContext, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const NotificationContext = createContext(null)
+
+export function NotificationProvider({ children }) {
+  const [toasts, setToasts] = useState([])
+  const [modalContent, setModalContent] = useState(null)
+
+  const showToast = (text, type = 'info', duration = 3000) => {
+    const id = Date.now()
+    setToasts((prev) => [...prev, { id, text, type }])
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id))
+    }, duration)
+  }
+
+  const showModal = (content) => setModalContent(content)
+  const closeModal = () => setModalContent(null)
+
+  const typeClass = (type) => {
+    switch (type) {
+      case 'success':
+        return 'bg-green-600'
+      case 'error':
+        return 'bg-red-600'
+      default:
+        return 'bg-blue-600'
+    }
+  }
+
+  return (
+    <NotificationContext.Provider value={{ showToast, showModal, closeModal }}>
+      {children}
+      {createPortal(
+        <div className="fixed top-4 right-4 z-[10000] space-y-2 pointer-events-none">
+          {toasts.map((t) => (
+            <div
+              key={t.id}
+              className={`pointer-events-auto px-4 py-2 rounded text-white shadow ${typeClass(t.type)}`}
+            >
+              {t.text}
+            </div>
+          ))}
+        </div>,
+        document.body
+      )}
+      {modalContent &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/50"
+            onClick={closeModal}
+          >
+            <div
+              className="bg-white p-6 rounded-lg shadow-lg max-h-[90vh] overflow-y-auto"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {modalContent}
+            </div>
+          </div>,
+          document.body
+        )}
+    </NotificationContext.Provider>
+  )
+}
+
+export function useNotification() {
+  return useContext(NotificationContext)
+}
+
+export default NotificationProvider
+

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { NotificationProvider } from '@/components/NotificationProvider.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <NotificationProvider>
+      <App />
+    </NotificationProvider>
   </StrictMode>,
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ MarkupSafe==3.0.2
 SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 Werkzeug==3.1.3
+pytest==8.3.3
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+import pytest
+
+# Ensure the application package can be imported
+sys.path.insert(0, os.path.abspath('.'))
+
+from src.main import app
+
+
+@pytest.fixture
+def client():
+    """Flask test client"""
+    with app.test_client() as client:
+        yield client
+
+
+@pytest.fixture
+def login(client):
+    """Helper to log in a user"""
+    def _login(username='admin', password='admin123'):
+        return client.post('/api/auth/login', json={'username': username, 'password': password})
+
+    return _login
+

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,41 @@
+def test_non_admin_cannot_generate_invite(client, login):
+    login(username='user1', password='user123')
+    resp = client.post('/api/admin/invite')
+    assert resp.status_code == 403
+
+
+def test_invite_signup_flow(client, login):
+    # Admin generates invite code
+    login()
+    invite = client.post('/api/admin/invite')
+    assert invite.status_code == 201
+    code = invite.get_json()['invite_code']
+    client.post('/api/auth/logout')
+
+    # Signup with invite code
+    signup = client.post('/api/auth/signup', json={
+        'username': 'pytestuser',
+        'password': 'pass123',
+        'name': 'Pytest User',
+        'invite_code': code
+    })
+    assert signup.status_code == 201
+
+    # Reusing code should fail
+    reuse = client.post('/api/auth/signup', json={
+        'username': 'pytestuser2',
+        'password': 'pass123',
+        'name': 'Another',
+        'invite_code': code
+    })
+    assert reuse.status_code == 403
+
+    # New user can log in
+    login(username='pytestuser', password='pass123')
+    client.post('/api/auth/logout')
+
+    # Cleanup the created user
+    login(username='antineutrino', password='b-decay')
+    delete = client.post('/api/superadmin/delete-account', json={'username': 'pytestuser'})
+    assert delete.status_code == 200
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,31 @@
+def test_login_logout_status(client, login):
+    resp = login()
+    assert resp.status_code == 200
+
+    status = client.get('/api/auth/status')
+    assert status.status_code == 200
+    data = status.get_json()
+    assert data['authenticated'] is True
+
+    client.post('/api/auth/logout')
+    status = client.get('/api/auth/status')
+    assert status.status_code == 200
+    data = status.get_json()
+    assert data['authenticated'] is False
+
+
+def test_login_failure(client):
+    resp = client.post('/api/auth/login', json={'username': 'admin', 'password': 'wrong'})
+    assert resp.status_code == 401
+
+
+def test_guest_login(client):
+    resp = client.post('/api/auth/guest')
+    assert resp.status_code == 200
+
+    status = client.get('/api/auth/status')
+    data = status.get_json()
+    assert status.status_code == 200
+    assert data['authenticated'] is True
+    assert data['user']['role'] == 'guest'
+

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -1,0 +1,23 @@
+import io
+
+
+def upload_csv(client):
+    csv_content = 'Last,First,Student ID\nDoe,John,123\nRoe,Jane,456\n'
+    data = {'file': (io.BytesIO(csv_content.encode('utf-8')), 'students.csv')}
+    return client.post('/api/csv/upload', data=data, content_type='multipart/form-data')
+
+
+def test_recording_categories_and_stats(client, login):
+    login()
+    assert upload_csv(client).status_code == 200
+    client.post('/api/session/create', json={'session_name': 'record_test'})
+
+    assert client.post('/api/record/clean', json={'input_value': '123'}).status_code == 200
+    assert client.post('/api/record/red', json={'input_value': '456'}).status_code == 200
+
+    status = client.get('/api/session/status')
+    assert status.status_code == 200
+    data = status.get_json()
+    assert data['clean_count'] == 1
+    assert data['red_count'] == 1
+

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,17 @@
+def test_create_and_list_session(client, login):
+    login()
+    create = client.post('/api/session/create', json={'session_name': 'pytest_session'})
+    assert create.status_code == 200
+    session_id = create.get_json()['session_id']
+
+    listing = client.get('/api/session/list')
+    assert listing.status_code == 200
+    data = listing.get_json()
+    assert any(s['session_id'] == session_id for s in data['sessions'])
+
+
+def test_guest_cannot_create_session(client):
+    client.post('/api/auth/guest')
+    resp = client.post('/api/session/create', json={'session_name': 'guest_session'})
+    assert resp.status_code == 401
+

--- a/tests/test_student_security.py
+++ b/tests/test_student_security.py
@@ -1,0 +1,53 @@
+import io
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from src.main import app
+
+
+def login(client, username='admin', password='admin123'):
+    return client.post('/api/auth/login', json={'username': username, 'password': password})
+
+
+def upload_sample_csv(client):
+    csv_content = 'Last,First,Student ID\nDoe,John,12345\n'
+    data = {
+        'file': (io.BytesIO(csv_content.encode('utf-8')), 'students.csv')
+    }
+    return client.post('/api/csv/upload', data=data, content_type='multipart/form-data')
+
+
+def test_records_store_only_names_and_csv_cleared_on_logout():
+    with app.test_client() as client:
+        # Login and upload CSV
+        resp = login(client)
+        assert resp.status_code == 200
+        assert upload_sample_csv(client).status_code == 200
+
+        # Create a session
+        client.post('/api/session/create', json={'session_name': 'Test'})
+
+        # Record student by ID
+        record_resp = client.post('/api/record/clean', json={'input_value': '12345'})
+        assert record_resp.status_code == 200
+
+        # Ensure record history contains name only
+        history_resp = client.get('/api/session/history')
+        data = history_resp.get_json()
+        assert history_resp.status_code == 200
+        assert 'scan_history' in data
+        assert data['scan_history'][0]['first_name'] == 'John'
+        assert 'Student ID' not in data['scan_history'][0]
+
+        # Logout to clear CSV data
+        client.post('/api/auth/logout')
+
+        # Login again and ensure CSV preview shows no data
+        login(client)
+        preview_resp = client.get('/api/csv/preview')
+        preview_data = preview_resp.get_json()
+        assert preview_resp.status_code == 200
+        assert preview_data['status'] == 'no_data'
+


### PR DESCRIPTION
## Summary
- replace ad-hoc popups with a notification provider offering toast and modal portals
- wrap the app in the provider so all pop-ups render above existing content
- generate invite codes through a modal with built-in copy button and success toast

## Testing
- `pytest`
- `npm --prefix frontend run lint` *(fails: Cannot find module '/workspace/goldenplatewebsite/frontend/node_modules/eslint/bin/eslint.js')*


------
https://chatgpt.com/codex/tasks/task_e_68c49bf8753c8320a15627dccdba69a2