### PR TITLE
fix: prevent unintended dialog closure

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -811,7 +811,7 @@ function App() {
 
         {/* Signup Dialog */}
         <Dialog open={showSignupDialog} onOpenChange={setShowSignupDialog}>
-          <DialogContent>
+          <DialogContent dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle>Create Account</DialogTitle>
               <DialogDescription>
@@ -1151,7 +1151,7 @@ function App() {
 
         {/* Category Recording Dialogs */}
         <Dialog open={showCleanDialog} onOpenChange={setShowCleanDialog}>
-          <DialogContent>
+          <DialogContent dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle className="text-yellow-600">🥇 Record as CLEAN PLATE</DialogTitle>
               <DialogDescription>
@@ -1184,7 +1184,7 @@ function App() {
         </Dialog>
 
         <Dialog open={showDirtyDialog} onOpenChange={setShowDirtyDialog}>
-          <DialogContent>
+          <DialogContent dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle className="text-orange-600">🍽️ Record as DIRTY PLATE</DialogTitle>
               <DialogDescription>
@@ -1217,7 +1217,7 @@ function App() {
         </Dialog>
 
         <Dialog open={showRedDialog} onOpenChange={setShowRedDialog}>
-          <DialogContent>
+          <DialogContent dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle className="text-red-600">🍝 Record as VERY DIRTY PLATE</DialogTitle>
               <DialogDescription>
@@ -1251,7 +1251,7 @@ function App() {
 
         {/* New Session Dialog */}
         <Dialog open={showNewSessionDialog} onOpenChange={setShowNewSessionDialog}>
-          <DialogContent>
+          <DialogContent dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle>Create New Session</DialogTitle>
               <DialogDescription>
@@ -1287,7 +1287,7 @@ function App() {
 
         {/* Delete Confirmation Dialog */}
         <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-          <DialogContent>
+          <DialogContent dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle className="text-red-600">Delete Session</DialogTitle>
               <DialogDescription>
@@ -1323,7 +1323,7 @@ function App() {
 
         {/* Dashboard Dialog */}
         <Dialog open={showDashboard} onOpenChange={setShowDashboard}>
-          <DialogContent className="max-w-2xl">
+          <DialogContent className="max-w-2xl" dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle>Dashboard</DialogTitle>
               <DialogDescription>
@@ -1362,7 +1362,7 @@ function App() {
 
         {/* Admin Panel Dialog */}
         <Dialog open={showAdminPanel} onOpenChange={setShowAdminPanel}>
-          <DialogContent className="max-w-4xl h-[90vh] overflow-y-auto">
+          <DialogContent className="max-w-4xl h-[90vh] overflow-y-auto" dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle className="text-red-600">Admin Panel</DialogTitle>
               <DialogDescription>
@@ -1464,7 +1464,7 @@ function App() {
 
         {/* Account Management Dialog */}
         <Dialog open={showAccountManagement} onOpenChange={setShowAccountManagement}>
-          <DialogContent className="max-w-2xl">
+          <DialogContent className="max-w-2xl" dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle>Account Management</DialogTitle>
               <DialogDescription>
@@ -1507,7 +1507,7 @@ function App() {
         </Dialog>
 
         <Dialog open={showUserDeleteConfirm} onOpenChange={setShowUserDeleteConfirm}>
-          <DialogContent>
+          <DialogContent dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle>Confirm Account Deletion</DialogTitle>
               <DialogDescription>
@@ -1536,7 +1536,7 @@ function App() {
 
         {/* Delete Requests Dialog */}
         <Dialog open={showDeleteRequests} onOpenChange={setShowDeleteRequests}>
-          <DialogContent className="max-w-2xl">
+          <DialogContent className="max-w-2xl" dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle>Delete Requests</DialogTitle>
               <DialogDescription>
@@ -1580,7 +1580,7 @@ function App() {
 
         {/* CSV Preview Dialog */}
         <Dialog open={showCsvPreview} onOpenChange={setShowCsvPreview}>
-          <DialogContent className="max-w-4xl max-h-[80vh]">
+          <DialogContent className="max-w-4xl max-h-[80vh]" dismissOnOverlayClick={false}>
             <DialogHeader>
               <DialogTitle>Student Database Preview</DialogTitle>
               <DialogDescription>
@@ -1661,7 +1661,7 @@ function App() {
       
       {/* Switch Session Dialog - Moved outside of conditional rendering */}
       <Dialog open={showSessionsDialog} onOpenChange={setShowSessionsDialog}>
-        <DialogContent>
+        <DialogContent dismissOnOverlayClick={false}>
           <DialogHeader>
             <DialogTitle>Switch Session</DialogTitle>
             <DialogDescription>
@@ -1738,7 +1738,11 @@ function App() {
       )}
 
       {modal?.type === 'invite' && (
-        <Modal open onClose={() => { setModal(null); setInviteCode('') }}>
+        <Modal
+          open
+          onClose={() => { setModal(null); setInviteCode('') }}
+          dismissOnOverlayClick={false}
+        >
           <h2 className="text-lg font-semibold mb-4">Invite Code</h2>
           <div className="flex items-center gap-2 mb-4">
             <Input value={inviteCode} readOnly className="flex-1" />

--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -1,14 +1,20 @@
 import React, { useEffect } from 'react'
 import { createPortal } from 'react-dom'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion as Motion } from 'framer-motion'
 
 /**
  * Modal component rendered via a React portal.
  * - Locks body scroll while open
- * - Closes on ESC key or overlay click
+ * - Closes on ESC key
+ * - Overlay click dismissal is controlled by `dismissOnOverlayClick`
  * - Animated with framer-motion for smooth appearance
+ *
+ * @param {boolean} open - Whether the modal is visible
+ * @param {() => void} onClose - Called when the modal requests to close
+ * @param {React.ReactNode} children - Modal content
+ * @param {boolean} [dismissOnOverlayClick=true] - Close when clicking the overlay
  */
-export default function Modal({ open, onClose, children }) {
+export default function Modal({ open, onClose, children, dismissOnOverlayClick = true }) {
   // Close on ESC and prevent background scrolling
   useEffect(() => {
     if (!open) return
@@ -30,14 +36,14 @@ export default function Modal({ open, onClose, children }) {
   return createPortal(
     <AnimatePresence>
       {open && (
-        <motion.div
+        <Motion.div
           className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/50 pointer-events-auto"
-          onClick={onClose}
+          onClick={dismissOnOverlayClick ? onClose : undefined}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
         >
-          <motion.div
+          <Motion.div
             role="dialog"
             aria-modal="true"
             onClick={(e) => e.stopPropagation()}
@@ -47,8 +53,8 @@ export default function Modal({ open, onClose, children }) {
             exit={{ scale: 0.95, opacity: 0 }}
           >
             {children}
-          </motion.div>
-        </motion.div>
+          </Motion.div>
+        </Motion.div>
       )}
     </AnimatePresence>,
     document.body

--- a/frontend/src/components/ui/command.jsx
+++ b/frontend/src/components/ui/command.jsx
@@ -40,7 +40,7 @@ function CommandDialog({
         <DialogTitle>{title}</DialogTitle>
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
-      <DialogContent className="overflow-hidden p-0">
+      <DialogContent className="overflow-hidden p-0" dismissOnOverlayClick={false}>
         <Command
           className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -43,11 +43,23 @@ function DialogOverlay({
   );
 }
 
+/**
+ * Dialog content container.
+ *
+ * @param {boolean} [dismissOnOverlayClick=true] - Close when clicking outside the dialog
+ */
 function DialogContent({
   className,
   children,
+  dismissOnOverlayClick = true,
+  onInteractOutside,
   ...props
 }) {
+  const handleInteractOutside = (event) => {
+    if (!dismissOnOverlayClick) event.preventDefault();
+    onInteractOutside?.(event);
+  };
+
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -57,10 +69,13 @@ function DialogContent({
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
-        {...props}>
+        onInteractOutside={handleInteractOutside}
+        {...props}
+      >
         {children}
         <DialogPrimitive.Close
-          className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+          className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+        >
           <XIcon />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>


### PR DESCRIPTION
## Summary
- add dismissOnOverlayClick to DialogContent and suppress outside dismissal when false
- disable overlay-based dismissal across all dialogs
- keep command palette open unless explicitly closed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find module '/workspace/goldenplatewebsite/frontend/node_modules/eslint/bin/eslint.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c58c49f29883209951ba13270eac6a