### PR TITLE
feat: add admin panel access from header

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -949,9 +949,28 @@ function App() {
               <Badge variant="outline" className="bg-amber-50 text-amber-700 border-amber-200">
                 {user.name} ({user.username})
               </Badge>
-              <Button 
+              {['admin', 'superadmin'].includes(user?.role) && (
+                <Button
+                  onClick={() => {
+                    loadAdminData()
+                    setShowAdminPanel(true)
+                  }}
+                  variant="outline"
+                  size="sm"
+                  className="relative text-red-600 hover:text-red-700"
+                >
+                  <Shield className="h-4 w-4 mr-2" />
+                  Admin Panel
+                  {deleteRequests.length > 0 && (
+                    <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs rounded-full px-2 py-0.5">
+                      {deleteRequests.length}
+                    </span>
+                  )}
+                </Button>
+              )}
+              <Button
                 onClick={() => window.open('https://github.com/Antineutrino-4444/goldenplatewebsite', '_blank')}
-                variant="outline" 
+                variant="outline"
                 size="sm"
                 className="text-gray-600 hover:text-gray-900"
               >


### PR DESCRIPTION
## Summary
- enable admins to open the admin panel directly from the header

## Testing
- `npm run lint` *(fails: no-unused-vars, react-hooks/exhaustive-deps)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c710738db48320817c3e426aa8e896