### PR TITLE
Remove admin panel button from header

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -954,25 +954,6 @@ function App() {
               <Badge variant="outline" className="bg-amber-50 text-amber-700 border-amber-200">
                 {user.name} ({user.username})
               </Badge>
-              {['admin', 'superadmin'].includes(user?.role) && (
-                <Button
-                  onClick={() => {
-                    setShowAdminPanel(true)
-                    loadAdminData()
-                  }}
-                  variant="outline"
-                  size="sm"
-                  className="relative text-red-600 hover:text-red-700"
-                >
-                  <Shield className="h-4 w-4 mr-2" />
-                  Admin Panel
-                  {deleteRequests.length > 0 && (
-                    <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs rounded-full px-2 py-0.5">
-                      {deleteRequests.length}
-                    </span>
-                  )}
-                </Button>
-              )}
               <Button
                 onClick={() => window.open('https://github.com/Antineutrino-4444/goldenplatewebsite', '_blank')}
                 variant="outline"


### PR DESCRIPTION
## Summary
- remove admin panel button from top bar

## Testing
- `npm -C frontend run lint` *(fails: Fast refresh only works when a file only exports components)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c74437f30883209762b92c00b52231