### PR TITLE
Support updated student CSV format and add detailed exports

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -465,8 +465,11 @@ function App() {
 
       const data = await response.json()
       if (response.ok) {
-        const displayName = `${data.first_name} ${data.last_name}`.trim()
-        showMessage(`${displayName} recorded as ${category.toUpperCase()}`, 'success')
+        const preferredName = (data.preferred_name ?? data.first_name ?? '').trim()
+        const lastName = (data.last_name ?? '').trim()
+        const nameParts = [preferredName, lastName].filter(Boolean)
+        const displayName = nameParts.join(' ')
+        showMessage(`${displayName || 'Student'} recorded as ${category.toUpperCase()}`, 'success')
         
         // Clear input and close dialog
         setPopupInputValue('')
@@ -544,6 +547,28 @@ function App() {
       }
     } catch (error) {
       showMessage('Failed to export records', 'error')
+    }
+  }
+
+  const exportDetailedCSV = async () => {
+    try {
+      const response = await fetch(`${API_BASE}/export/csv/detailed`)
+      if (response.ok) {
+        const blob = await response.blob()
+        const url = window.URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `${sessionName}_detailed_records.csv`
+        document.body.appendChild(a)
+        a.click()
+        window.URL.revokeObjectURL(url)
+        document.body.removeChild(a)
+        showMessage('Detailed records exported successfully', 'success')
+      } else {
+        showMessage('Failed to export detailed records', 'error')
+      }
+    } catch (error) {
+      showMessage('Failed to export detailed records', 'error')
     }
   }
 
@@ -1073,7 +1098,7 @@ function App() {
                 Student Database
               </CardTitle>
               <CardDescription>
-                Upload CSV with student data for food waste tracking (Last, First, Student ID)
+                Upload CSV with student data for food waste tracking (Student ID, Last, Preferred, Grade, Advisor, House, Clan)
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -1124,10 +1149,16 @@ function App() {
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <Button onClick={exportCSV} className="w-full bg-amber-600 hover:bg-amber-700">
-                  <Download className="h-4 w-4 mr-2" />
-                  Export Food Waste Data
-                </Button>
+                <div className="flex flex-col gap-2">
+                  <Button onClick={exportCSV} className="w-full bg-amber-600 hover:bg-amber-700">
+                    <Download className="h-4 w-4 mr-2" />
+                    Export Food Waste Data
+                  </Button>
+                  <Button onClick={exportDetailedCSV} variant="outline" className="w-full">
+                    <FileText className="h-4 w-4 mr-2" />
+                    Export Detailed Record List
+                  </Button>
+                </div>
               </CardContent>
             </Card>
           )}

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -2,7 +2,9 @@ import io
 
 
 def upload_csv(client):
-    csv_content = 'Last,First,Student ID\nDoe,John,123\nRoe,Jane,456\n'
+    csv_content = 'Student ID,Last,Preferred,Grade,Advisor,House,Clan\n'
+    csv_content += '123,Doe,John,9,Smith,Barn,Alpha\n'
+    csv_content += '456,Roe,Jane,10,Jones,Hall,Beta\n'
     data = {'file': (io.BytesIO(csv_content.encode('utf-8')), 'students.csv')}
     return client.post('/api/csv/upload', data=data, content_type='multipart/form-data')
 

--- a/tests/test_student_security.py
+++ b/tests/test_student_security.py
@@ -12,7 +12,8 @@ def login(client, username='antineutrino', password='b-decay'):
 
 
 def upload_sample_csv(client):
-    csv_content = 'Last,First,Student ID\nDoe,John,12345\n'
+    csv_content = 'Student ID,Last,Preferred,Grade,Advisor,House,Clan\n'
+    csv_content += '12345,Doe,John,9,Smith,Barn,Alpha\n'
     data = {
         'file': (io.BytesIO(csv_content.encode('utf-8')), 'students.csv')
     }
@@ -38,8 +39,11 @@ def test_records_store_only_names_and_csv_cleared_on_logout():
         data = history_resp.get_json()
         assert history_resp.status_code == 200
         assert 'scan_history' in data
-        assert data['scan_history'][0]['first_name'] == 'John'
-        assert 'Student ID' not in data['scan_history'][0]
+        record = data['scan_history'][0]
+        assert record['preferred_name'] == 'John'
+        assert record['grade'] == '9'
+        assert 'Student ID' not in record
+        assert 'student_id' not in record
 
         # Logout to clear CSV data
         client.post('/api/auth/logout')


### PR DESCRIPTION
## Summary
- ensure the recorder seeds a default super admin when the user store is empty and require the new student CSV headers while capturing extended metadata for each session record
- add a detailed CSV export without student IDs for both the file-based and database-backed recorders
- align the React client and automated tests with the new preferred-name schema and expose a detailed record download option

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9a0a3f4388320bbe5d91691655786