### PR TITLE
Add faculty clean tracking and convert dirty plate to counter

### DIFF
--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -16,10 +16,15 @@ def test_recording_categories_and_stats(client, login):
 
     assert client.post('/api/record/clean', json={'input_value': '123'}).status_code == 200
     assert client.post('/api/record/red', json={'input_value': '456'}).status_code == 200
+    assert client.post('/api/record/dirty', json={}).status_code == 200
+    assert client.post('/api/record/faculty', json={'input_value': 'Dr Jane Smith'}).status_code == 200
 
     status = client.get('/api/session/status')
     assert status.status_code == 200
     data = status.get_json()
     assert data['clean_count'] == 1
     assert data['red_count'] == 1
+    assert data['dirty_count'] == 1
+    assert data['faculty_clean_count'] == 1
+    assert data['combined_dirty_count'] == 2
 


### PR DESCRIPTION
## Summary
- add persistent helpers to normalize sessions, keep dirty plates as a counter, and track faculty clean records on the API
- adjust record, status, list, and export routes to serve faculty data and include the dirty count-only behaviour
- update the frontend workflow with a faculty recording tab, counter-only dirty dialog, UI summaries, and supporting tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cd93082680832089ece7c73c5373c1