### PR TITLE
Add optional comments to draw actions

### DIFF
--- a/frontend/src/components/MainPortal.jsx
+++ b/frontend/src/components/MainPortal.jsx
@@ -60,6 +60,8 @@ function MainPortal({ app }) {
     discardLoading,
     isDrawCenterCollapsed,
     setIsDrawCenterCollapsed,
+    drawActionComment,
+    setDrawActionComment,
     facultyPick,
     facultyPickLoading,
     pickRandomFaculty,
@@ -582,6 +584,20 @@ function MainPortal({ app }) {
                               Reset Draw
                             </Button>
                           </div>
+                          <div className="flex flex-col gap-1">
+                            <Label htmlFor="draw-action-comment" className="text-xs text-gray-600">
+                              Action comment (optional)
+                            </Label>
+                            <Input
+                              id="draw-action-comment"
+                              value={drawActionComment}
+                              onChange={(event) => setDrawActionComment(event.target.value)}
+                              placeholder="Add context for this draw action"
+                            />
+                            <p className="text-xs text-gray-500">
+                              The note is saved to the draw history when you start, finalize, reset, or override.
+                            </p>
+                          </div>
                           <div className="flex w-full flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                             <div>
                               <div className="text-sm text-gray-500">Random Faculty Picker</div>
@@ -792,6 +808,7 @@ function MainPortal({ app }) {
                                             <div>Eligible pool: {entry.pool_size}</div>
                                           )}
                                           {entry.created_by && <div>By: {entry.created_by}</div>}
+                                          {entry.comment && <div className="text-gray-700">Comment: {entry.comment}</div>}
                                         </div>
                                       ))}
                                   </div>

--- a/src/routes/golden_plate_recorder_db/db.py
+++ b/src/routes/golden_plate_recorder_db/db.py
@@ -249,6 +249,7 @@ class SessionDrawEvent(Base):
     tickets_at_event = Column(Integer)
     probability_at_event = Column(Integer)
     eligible_pool_size = Column(Integer)
+    comment = Column(Text)
     created_at = Column(DateTime(timezone=True), default=_now_utc)
     created_by = Column(String, ForeignKey('users.id'))
 
@@ -627,6 +628,7 @@ def _migrate_schema() -> None:
                     tickets_at_event INTEGER,
                     probability_at_event INTEGER,
                     eligible_pool_size INTEGER,
+                    comment TEXT,
                     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     created_by TEXT REFERENCES users(id)
                 )
@@ -664,6 +666,11 @@ def _migrate_schema() -> None:
                 '''
             ))
             connection.execute(text('DROP TABLE session_draw_events_old'))
+        inspector = inspect(engine)
+        tables = set(inspector.get_table_names())
+
+    if 'session_draw_events' in tables:
+        _ensure_column(inspector, 'session_draw_events', 'comment', 'TEXT')
         inspector = inspect(engine)
         tables = set(inspector.get_table_names())
 


### PR DESCRIPTION
## Summary
- allow draw actions to include optional comments that are saved with draw history entries
- add backend support for storing comment text on draw events and include it in history responses
- expose comment input in the Draw Center and display stored comments alongside history entries

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c779ab2c8320b7c635f0ecc203cb)