### PR TITLE
Persist faculty picker selections in DB-backed sessions

### DIFF
--- a/frontend/src/hooks/usePlateApp.js
+++ b/frontend/src/hooks/usePlateApp.js
@@ -214,7 +214,9 @@ export function usePlateApp() {
   const isInterschoolUser = user?.role === 'inter_school'
 
   useEffect(() => {
-    setFacultyPick(null)
+    if (!sessionId) {
+      setFacultyPick(null)
+    }
   }, [sessionId])
 
   const buildDrawActionPayload = () => {
@@ -609,6 +611,7 @@ export function usePlateApp() {
           is_discarded: data.is_discarded ?? false,
           draw_info: data.draw_info ?? null
         })
+        setFacultyPick(data.faculty_pick ?? null)
         await loadScanHistory()
         await loadStudentNames()
         await loadTeacherNames()
@@ -632,6 +635,7 @@ export function usePlateApp() {
             is_discarded: false,
             draw_info: null
           })
+          setFacultyPick(null)
           setScanHistory([])
           setDrawSummary(null)
           setOverrideInput('')
@@ -655,6 +659,7 @@ export function usePlateApp() {
         clean_percentage: 0,
         dirty_percentage: 0
       })
+      setFacultyPick(null)
       setScanHistory([])
       setDrawSummary(null)
       setOverrideInput('')
@@ -726,6 +731,7 @@ export function usePlateApp() {
   const switchSession = async (targetSessionId) => {
     setIsLoading(true)
     try {
+      setFacultyPick(null)
       const response = await fetch(`${API_BASE}/session/switch/${targetSessionId}`, {
         method: 'POST'
       })
@@ -1028,6 +1034,7 @@ export function usePlateApp() {
           is_discarded: data.is_discarded ?? prev.is_discarded,
           draw_info: data.draw_info ?? prev.draw_info
         }))
+        setFacultyPick(data.faculty_pick ?? null)
         nextSessionId = data.session_id ?? nextSessionId
         nextSessionName = data.session_name ?? nextSessionName
         if (data.is_discarded !== undefined) {

--- a/src/routes/golden_plate_recorder_db/db.py
+++ b/src/routes/golden_plate_recorder_db/db.py
@@ -207,6 +207,11 @@ class Session(Base):
     probability_at_selection = Column(Integer)
     eligible_pool_size = Column(Integer)
     override_applied = Column(Integer, nullable=False, default=0)
+    faculty_pick_preferred_name = Column(String)
+    faculty_pick_last_name = Column(String)
+    faculty_pick_display_name = Column(String)
+    faculty_pick_recorded_at = Column(DateTime(timezone=True))
+    faculty_pick_recorded_by = Column(String, ForeignKey('users.id'))
 
 
 class SessionRecord(Base):
@@ -606,6 +611,11 @@ def _migrate_schema() -> None:
             ('probability_at_selection', 'INTEGER'),
             ('eligible_pool_size', 'INTEGER'),
             ('override_applied', 'INTEGER DEFAULT 0'),
+            ('faculty_pick_preferred_name', 'TEXT'),
+            ('faculty_pick_last_name', 'TEXT'),
+            ('faculty_pick_display_name', 'TEXT'),
+            ('faculty_pick_recorded_at', 'DATETIME'),
+            ('faculty_pick_recorded_by', 'TEXT'),
         ]:
             if column_name not in session_columns:
                 with engine.begin() as connection:

--- a/src/routes/golden_plate_recorder_db/storage.py
+++ b/src/routes/golden_plate_recorder_db/storage.py
@@ -369,6 +369,9 @@ def ensure_session_structure(session_info):
     if 'scan_history' not in session_info or not isinstance(session_info['scan_history'], list):
         session_info['scan_history'] = []
 
+    if 'faculty_pick' not in session_info:
+        session_info['faculty_pick'] = None
+
     # Strip any stored names from historic dirty scan history entries
     for record in session_info['scan_history']:
         if record.get('category') == 'dirty':
@@ -483,6 +486,20 @@ def hydrate_session_from_db(session_id, *, persist=True, session_model=None):
     if db_sess.discarded_by and not discard_metadata.get('discarded_by'):
         discard_metadata['discarded_by'] = db_sess.discarded_by
     session_info['discard_metadata'] = discard_metadata
+    if (
+        db_sess.faculty_pick_display_name
+        or db_sess.faculty_pick_preferred_name
+        or db_sess.faculty_pick_last_name
+    ):
+        session_info['faculty_pick'] = {
+            'preferred_name': db_sess.faculty_pick_preferred_name,
+            'last_name': db_sess.faculty_pick_last_name,
+            'display_name': db_sess.faculty_pick_display_name,
+            'recorded_at': _isoformat_timestamp(db_sess.faculty_pick_recorded_at),
+            'recorded_by': db_sess.faculty_pick_recorded_by,
+        }
+    else:
+        session_info.setdefault('faculty_pick', None)
 
     try:
         records = (


### PR DESCRIPTION
### Motivation
- Persist faculty picker selections so a chosen faculty entry survives session refreshes and switches and is stored in the primary relational DB.
- Maintain backward compatibility with existing JSON `session_data` cache so older sessions and the UI keep working.
- Surface the saved faculty pick to the frontend so the UI can restore the selection on load or session switch.
- Ensure draw-related comments remain compatible (draw comments are already stored in `session_draw_events`).

### Description
- Added new session columns in `src/routes/golden_plate_recorder_db/db.py` (`faculty_pick_preferred_name`, `faculty_pick_last_name`, `faculty_pick_display_name`, `faculty_pick_recorded_at`, `faculty_pick_recorded_by`) and migration logic to add these columns when missing.
- Persist the chosen faculty in `pick_random_faculty` by saving the payload into both the `sessions` table columns and the JSON `session_data`, then committing via `db_session.commit()` in `src/routes/golden_plate_recorder_db/session_routes.py`.
- Hydration and storage updates in `src/routes/golden_plate_recorder_db/storage.py` to include `faculty_pick` in `ensure_session_structure` and to populate it from DB fields during `hydrate_session_from_db`.
- Frontend updates in `frontend/src/hooks/usePlateApp.js` to load and keep `faculty_pick` in state on `initializeSession`, `refreshSessionStatus`, `switchSession`, and session creation flows so the UI restores the persisted pick.

### Testing
- No automated tests were executed for this change.
- Basic repository-level commit recorded (`Persist faculty picks in session data`) but no CI/test run output is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fcb85ebd08320bf59eef6afc2010b)