### PR TITLE
Add house breakdown to session dashboard

### DIFF
--- a/frontend/src/components/MainPortal.jsx
+++ b/frontend/src/components/MainPortal.jsx
@@ -154,6 +154,20 @@ function MainPortal({ app }) {
     userToDelete,
     deleteUserAccount
   } = app
+  const [houseSortKey, setHouseSortKey] = React.useState('percentage')
+  const houseSummary = Array.isArray(sessionStats.house_summary) ? sessionStats.house_summary : []
+  const houseTotal = Number(sessionStats.house_total ?? 0) || houseSummary.reduce((sum, entry) => sum + Number(entry.count ?? 0), 0)
+  const sortedHouseSummary = React.useMemo(() => {
+    const next = [...houseSummary]
+    const sortField = houseSortKey === 'count' ? 'count' : 'percentage'
+    return next.sort((a, b) => {
+      const primary = Number(b[sortField] ?? 0) - Number(a[sortField] ?? 0)
+      if (primary !== 0) {
+        return primary
+      }
+      return String(a.house ?? '').localeCompare(String(b.house ?? ''))
+    })
+  }, [houseSummary, houseSortKey])
 
   const formatSchoolNameWithCode = (school) => {
     if (!school?.name) {
@@ -1471,6 +1485,52 @@ function MainPortal({ app }) {
                   )}
                 </div>
               </div>
+
+              {sortedHouseSummary.length > 0 && (
+                <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 text-sm font-semibold text-gray-700">
+                      <Building2 className="h-4 w-4" />
+                      House breakdown
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant={houseSortKey === 'percentage' ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => setHouseSortKey('percentage')}
+                      >
+                        Sort by %
+                      </Button>
+                      <Button
+                        variant={houseSortKey === 'count' ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => setHouseSortKey('count')}
+                      >
+                        Sort by count
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="mt-3 space-y-2">
+                    <div className="flex items-center justify-between text-xs text-gray-500">
+                      <span>House</span>
+                      <span>Records</span>
+                    </div>
+                    <div className="space-y-2">
+                      {sortedHouseSummary.map((entry) => (
+                        <div key={entry.house} className="flex items-center justify-between rounded-md border border-gray-100 px-3 py-2 text-sm">
+                          <div className="font-medium text-gray-800">{entry.house}</div>
+                          <div className="text-xs text-gray-500">
+                            {Number(entry.count ?? 0).toLocaleString()} • {Number(entry.percentage ?? 0).toFixed(1)}%
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="pt-1 text-xs text-gray-500">
+                      {houseTotal.toLocaleString()} total records with house data
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/frontend/src/hooks/usePlateApp.js
+++ b/frontend/src/hooks/usePlateApp.js
@@ -43,7 +43,9 @@ export function usePlateApp() {
     clean_percentage: 0,
     dirty_percentage: 0,
     is_discarded: false,
-    draw_info: null
+    draw_info: null,
+    house_total: 0,
+    house_summary: []
   })
   const [isLoading, setIsLoading] = useState(false)
   
@@ -302,7 +304,9 @@ export function usePlateApp() {
       clean_percentage: 0,
       dirty_percentage: 0,
       is_discarded: false,
-      draw_info: null
+      draw_info: null,
+      house_total: 0,
+      house_summary: []
     })
     setDrawSummary(null)
     setOverrideInput('')
@@ -566,7 +570,9 @@ export function usePlateApp() {
         clean_percentage: 0,
         dirty_percentage: 0,
         is_discarded: false,
-        draw_info: null
+        draw_info: null,
+        house_total: 0,
+        house_summary: []
       })
       setInviteCode('')
       setModal(null)
@@ -609,7 +615,9 @@ export function usePlateApp() {
           clean_percentage: data.clean_percentage,
           dirty_percentage: data.dirty_percentage,
           is_discarded: data.is_discarded ?? false,
-          draw_info: data.draw_info ?? null
+          draw_info: data.draw_info ?? null,
+          house_total: data.house_total ?? 0,
+          house_summary: data.house_summary ?? []
         })
         setFacultyPick(data.faculty_pick ?? null)
         await loadScanHistory()
@@ -633,7 +641,9 @@ export function usePlateApp() {
             clean_percentage: 0,
             dirty_percentage: 0,
             is_discarded: false,
-            draw_info: null
+            draw_info: null,
+            house_total: 0,
+            house_summary: []
           })
           setFacultyPick(null)
           setScanHistory([])
@@ -657,7 +667,11 @@ export function usePlateApp() {
         combined_dirty_count: 0,
         total_recorded: 0,
         clean_percentage: 0,
-        dirty_percentage: 0
+        dirty_percentage: 0,
+        is_discarded: false,
+        draw_info: null,
+        house_total: 0,
+        house_summary: []
       })
       setFacultyPick(null)
       setScanHistory([])
@@ -689,7 +703,11 @@ export function usePlateApp() {
           combined_dirty_count: 0,
           total_recorded: 0,
           clean_percentage: 0,
-          dirty_percentage: 0
+          dirty_percentage: 0,
+          is_discarded: false,
+          draw_info: null,
+          house_total: 0,
+          house_summary: []
         })
         await refreshSessionStatus({
           sessionIdOverride: data.session_id,
@@ -1032,7 +1050,9 @@ export function usePlateApp() {
           clean_percentage: data.clean_percentage,
           dirty_percentage: data.dirty_percentage,
           is_discarded: data.is_discarded ?? prev.is_discarded,
-          draw_info: data.draw_info ?? prev.draw_info
+          draw_info: data.draw_info ?? prev.draw_info,
+          house_total: data.house_total ?? prev.house_total ?? 0,
+          house_summary: data.house_summary ?? prev.house_summary ?? []
         }))
         setFacultyPick(data.faculty_pick ?? null)
         nextSessionId = data.session_id ?? nextSessionId


### PR DESCRIPTION
### Motivation

- Sessions should expose per-house counts and percentages when house data is present in the DB so the UI can show house rankings for a session.
- The dashboard needs a separate panel to display house ranking and allow sorting by percentage or absolute count.

### Description

- Added server-side aggregation in `src/routes/golden_plate_recorder_db/session_routes.py` to compute `house_total` and `house_summary` and include them in the `/session/status` response.
- Extended client session state in `frontend/src/hooks/usePlateApp.js` to track `house_total` and `house_summary` and to populate them from `GET /session/status` and refresh paths (`initializeSession`, `refreshSessionStatus`, etc.).
- Added a dashboard panel in `frontend/src/components/MainPortal.jsx` that renders the house breakdown and provides buttons to sort by percentage or count; the panel shows house name, record count and percentage and a total with house record count.
- Minor UI plumbing: memoized sorting (`houseSortKey`) and safe fallbacks when `house_summary` is absent.

### Testing

- No automated tests were run for this change.
- Basic type-level/usage integration performed in code (client state updates and UI rendering hooks) but no automated assertions were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69653e0155f883209df01bad64057397)