### PR TITLE
Add house data panel with ranking display

### DIFF
--- a/frontend/src/hooks/usePlateApp.js
+++ b/frontend/src/hooks/usePlateApp.js
@@ -104,6 +104,12 @@ export function usePlateApp() {
   const [facultyPickLoading, setFacultyPickLoading] = useState(false)
   const [drawActionComment, setDrawActionComment] = useState('')
 
+  // House stats state
+  const [houseStats, setHouseStats] = useState(null)
+  const [houseStatsLoading, setHouseStatsLoading] = useState(false)
+  const [showHouseDataPanel, setShowHouseDataPanel] = useState(false)
+  const [houseSortBy, setHouseSortBy] = useState('count') // 'count' or 'percentage'
+
   // Notification and modal states
   const [notification, setNotification] = useState(null)
   const [modal, setModal] = useState(null)
@@ -1211,6 +1217,36 @@ export function usePlateApp() {
     }
   }
 
+  const loadHouseStats = async ({ silent = false, sessionIdOverride = null } = {}) => {
+    const targetSessionId = sessionIdOverride || sessionId
+    if (!targetSessionId) {
+      setHouseStats(null)
+      return
+    }
+
+    setHouseStatsLoading(true)
+    try {
+      const response = await fetch(`${API_BASE}/session/${targetSessionId}/house-stats`)
+      const data = await response.json()
+      if (response.ok) {
+        setHouseStats(data)
+      } else {
+        if (!silent) {
+          showMessage(data.error || 'Failed to load house statistics', 'error')
+        }
+        setHouseStats(null)
+      }
+    } catch (error) {
+      console.error('Failed to load house stats:', error)
+      if (!silent) {
+        showMessage('Failed to load house statistics', 'error')
+      }
+      setHouseStats(null)
+    } finally {
+      setHouseStatsLoading(false)
+    }
+  }
+
   const applyDrawResponse = (data, { silent = false } = {}) => {
     if (!data) {
       return
@@ -2007,6 +2043,10 @@ export function usePlateApp() {
     sessionDashboardStats,
     dashboardWinner,
     isInterschoolUser,
+    houseStats,
+    houseStatsLoading,
+    showHouseDataPanel,
+    houseSortBy,
 
     // actions
     checkAuthStatus,
@@ -2067,6 +2107,9 @@ export function usePlateApp() {
     changeUserRole,
     deleteUserAccount,
     sanitizeSelection,
-    resetSchoolRegistrationForm
+    resetSchoolRegistrationForm,
+    loadHouseStats,
+    setShowHouseDataPanel,
+    setHouseSortBy
   }
 }


### PR DESCRIPTION
- Add backend endpoint GET /api/session/<session_id>/house-stats that aggregates house statistics from session records
- Add frontend state and loadHouseStats function in usePlateApp hook
- Create House Data panel dialog showing house rankings with:
  - Sortable by absolute count or percentage
  - Displays clean count, very dirty count, total count, percentage, and clean rate
  - Refresh button to reload stats
- Add House Data button in session controls toolbar