### PR TITLE
Display user ID in superadmin panel

### DIFF
--- a/frontend/src/components/MainPortal.jsx
+++ b/frontend/src/components/MainPortal.jsx
@@ -1881,6 +1881,9 @@ function MainPortal({ app }) {
                   {user.role === 'superadmin' && userAccount.password && (
                     <div className="text-xs text-gray-500">Password: {userAccount.password}</div>
                   )}
+                  {user.role === 'superadmin' && userAccount.id && (
+                    <div className="text-xs text-gray-400 font-mono">ID: {userAccount.id}</div>
+                  )}
                 </div>
                 <div className="flex items-center gap-2">
                   <Badge

--- a/src/routes/golden_plate_recorder_db/admin_routes.py
+++ b/src/routes/golden_plate_recorder_db/admin_routes.py
@@ -92,6 +92,7 @@ def admin_get_users():
     include_password = current_user['role'] == 'superadmin'
     for user in list_all_users(school_id=current_school_id, include_password=include_password):
         payload = {
+            'id': user['id'],
             'username': user['username'],
             'name': user['name'],
             'role': user['role'],


### PR DESCRIPTION
Add user ID (UUID) to the /admin/users API response and display it in the Account Management dialog for superadmins.