### PR TITLE
Fix email verification for school sign-up

### DIFF
--- a/frontend/src/hooks/usePlateApp.js
+++ b/frontend/src/hooks/usePlateApp.js
@@ -336,7 +336,12 @@ export function usePlateApp() {
         showMessage('Verification code sent to your email!', 'success')
         return true
       } else {
-        showMessage(data.error || 'Failed to send verification code', 'error')
+        // Show detailed error if available (helps with debugging)
+        const errorMsg = data.detail
+          ? `${data.error} (${data.detail})`
+          : data.error || 'Failed to send verification code'
+        showMessage(errorMsg, 'error')
+        console.error('Email verification error:', data)
         return false
       }
     } catch (error) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 blinker==1.9.0
+python-dotenv==1.0.1
 click==8.2.1
 Flask==3.1.1
 flask-cors==6.0.0

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,18 @@
+import logging
 import os
 import sys
 # DON'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from dotenv import load_dotenv
+# Load environment variables from .env file
+load_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
 
 from flask import Flask, send_from_directory
 from flask_cors import CORS


### PR DESCRIPTION
- Add python-dotenv to requirements and load .env file in main.py
- Read BREVO_API_KEY at runtime instead of import time to ensure environment variables are loaded first
- Add proper logging to email_service.py for debugging email issues
- Show detailed error messages in frontend when email sending fails
- Fix issue where "Failed to send verification email" showed generic error instead of actual cause (e.g., missing API key)