### PR TITLE
Add legacy invite signup flows and default house count sort

### DIFF
--- a/frontend/src/components/LoginView.jsx
+++ b/frontend/src/components/LoginView.jsx
@@ -33,6 +33,10 @@ function LoginView({ app }) {
     setSignupName,
     signupSchoolCode,
     setSignupSchoolCode,
+    signupInviteCode,
+    setSignupInviteCode,
+    signupMode,
+    setSignupMode,
     signup,
     setShowSchoolRegistration,
     resetSchoolRegistrationForm,
@@ -60,6 +64,10 @@ function LoginView({ app }) {
     setShowSignupDialog(open)
     if (!open && recaptchaRef.current) {
       recaptchaRef.current.reset()
+    }
+    if (!open) {
+      setSignupInviteCode('')
+      setSignupMode('school')
     }
   }
 
@@ -206,6 +214,42 @@ function LoginView({ app }) {
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-2">
+              <Label>Sign-up method</Label>
+              <div className="flex border rounded-lg overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSignupMode('school')
+                    setSignupInviteCode('')
+                  }}
+                  className={`px-3 py-1.5 text-sm flex-1 transition-colors ${
+                    signupMode === 'school'
+                      ? 'bg-amber-600 text-white'
+                      : 'bg-white text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  School Code
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSignupMode('invite')
+                    setSignupSchoolCode('')
+                  }}
+                  className={`px-3 py-1.5 text-sm flex-1 transition-colors ${
+                    signupMode === 'invite'
+                      ? 'bg-amber-600 text-white'
+                      : 'bg-white text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  Legacy Invite
+                </button>
+              </div>
+              <p className="text-xs text-gray-500">
+                Use a legacy invite code for immediate access, or request approval with your school code.
+              </p>
+            </div>
+            <div className="space-y-2">
               <Label htmlFor="signup-name">Full Name</Label>
               <Input
                 id="signup-name"
@@ -235,19 +279,35 @@ function LoginView({ app }) {
                 onChange={(e) => setSignupPassword(e.target.value)}
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="signup-school">School Code</Label>
-              <Input
-                id="signup-school"
-                type="text"
-                placeholder="Enter your school code (e.g., SAC)"
-                value={signupSchoolCode}
-                onChange={(e) => setSignupSchoolCode(e.target.value)}
-              />
-              <p className="text-xs text-gray-500">
-                Ask your school administrator for your school code.
-              </p>
-            </div>
+            {signupMode === 'school' ? (
+              <div className="space-y-2">
+                <Label htmlFor="signup-school">School Code</Label>
+                <Input
+                  id="signup-school"
+                  type="text"
+                  placeholder="Enter your school code (e.g., SAC)"
+                  value={signupSchoolCode}
+                  onChange={(e) => setSignupSchoolCode(e.target.value)}
+                />
+                <p className="text-xs text-gray-500">
+                  Ask your school administrator for your school code.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <Label htmlFor="signup-invite">Legacy Invite Code</Label>
+                <Input
+                  id="signup-invite"
+                  type="text"
+                  placeholder="Enter your invite code"
+                  value={signupInviteCode}
+                  onChange={(e) => setSignupInviteCode(e.target.value)}
+                />
+                <p className="text-xs text-gray-500">
+                  Enter the one-time invite code provided by your administrator.
+                </p>
+              </div>
+            )}
             {RECAPTCHA_SITE_KEY && (
               <div className="flex justify-center">
                 <ReCAPTCHA

--- a/frontend/src/components/MainPortal.jsx
+++ b/frontend/src/components/MainPortal.jsx
@@ -476,17 +476,6 @@ function MainPortal({ app }) {
                           <span className="text-sm text-gray-500">Sort by:</span>
                           <div className="flex border rounded-lg overflow-hidden">
                             <button
-                              onClick={() => setHouseSortBy('percentage')}
-                              className={`px-3 py-1.5 text-sm flex items-center gap-1 transition-colors ${
-                                houseSortBy === 'percentage'
-                                  ? 'bg-teal-600 text-white'
-                                  : 'bg-white text-gray-700 hover:bg-gray-50'
-                              }`}
-                            >
-                              <ArrowUpNarrowWide className="h-3.5 w-3.5" />
-                              Clean Rate
-                            </button>
-                            <button
                               onClick={() => setHouseSortBy('count')}
                               className={`px-3 py-1.5 text-sm flex items-center gap-1 transition-colors ${
                                 houseSortBy === 'count'
@@ -496,6 +485,17 @@ function MainPortal({ app }) {
                             >
                               <ArrowDownNarrowWide className="h-3.5 w-3.5" />
                               Count
+                            </button>
+                            <button
+                              onClick={() => setHouseSortBy('percentage')}
+                              className={`px-3 py-1.5 text-sm flex items-center gap-1 transition-colors ${
+                                houseSortBy === 'percentage'
+                                  ? 'bg-teal-600 text-white'
+                                  : 'bg-white text-gray-700 hover:bg-gray-50'
+                              }`}
+                            >
+                              <ArrowUpNarrowWide className="h-3.5 w-3.5" />
+                              Clean Rate
                             </button>
                           </div>
                           <Button
@@ -1015,17 +1015,6 @@ function MainPortal({ app }) {
                         <span className="text-sm text-gray-500">Sort by:</span>
                         <div className="flex border rounded-lg overflow-hidden">
                           <button
-                            onClick={() => setHouseSortBy('percentage')}
-                            className={`px-3 py-1.5 text-sm flex items-center gap-1 transition-colors ${
-                              houseSortBy === 'percentage'
-                                ? 'bg-teal-600 text-white'
-                                : 'bg-white text-gray-700 hover:bg-gray-50'
-                            }`}
-                          >
-                            <ArrowUpNarrowWide className="h-3.5 w-3.5" />
-                            Clean Rate
-                          </button>
-                          <button
                             onClick={() => setHouseSortBy('count')}
                             className={`px-3 py-1.5 text-sm flex items-center gap-1 transition-colors ${
                               houseSortBy === 'count'
@@ -1035,6 +1024,17 @@ function MainPortal({ app }) {
                           >
                             <ArrowDownNarrowWide className="h-3.5 w-3.5" />
                             Count
+                          </button>
+                          <button
+                            onClick={() => setHouseSortBy('percentage')}
+                            className={`px-3 py-1.5 text-sm flex items-center gap-1 transition-colors ${
+                              houseSortBy === 'percentage'
+                                ? 'bg-teal-600 text-white'
+                                : 'bg-white text-gray-700 hover:bg-gray-50'
+                            }`}
+                          >
+                            <ArrowUpNarrowWide className="h-3.5 w-3.5" />
+                            Clean Rate
                           </button>
                         </div>
                         <Button

--- a/frontend/src/components/SchoolRegistration.jsx
+++ b/frontend/src/components/SchoolRegistration.jsx
@@ -16,6 +16,12 @@ function SchoolRegistration({ app }) {
     setSchoolName,
     schoolCode,
     setSchoolCode,
+    schoolInviteCode,
+    setSchoolInviteCode,
+    schoolInviteSchoolId,
+    setSchoolInviteSchoolId,
+    schoolSignupMode,
+    setSchoolSignupMode,
     schoolAdminUsername,
     setSchoolAdminUsername,
     schoolAdminPassword,
@@ -36,6 +42,7 @@ function SchoolRegistration({ app }) {
   } = app
 
   const recaptchaRef = useRef(null)
+  const isInviteMode = schoolSignupMode === 'invite'
 
   const handleBackToLogin = () => {
     resetSchoolRegistrationForm()
@@ -74,81 +81,149 @@ function SchoolRegistration({ app }) {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* Step 1: Email Verification */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2 mb-2">
-              <div className={`w-6 h-6 rounded-full flex items-center justify-center text-sm font-bold ${emailVerified ? 'bg-green-500 text-white' : 'bg-amber-500 text-white'}`}>
-                {emailVerified ? '✓' : '1'}
-              </div>
-              <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
-                Verify Your Email
-              </h3>
+          <div className="space-y-2">
+            <Label>Registration Method</Label>
+            <div className="flex border rounded-lg overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setSchoolSignupMode('request')}
+                className={`px-3 py-1.5 text-sm flex-1 transition-colors ${
+                  schoolSignupMode === 'request'
+                    ? 'bg-amber-600 text-white'
+                    : 'bg-white text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                Email Verification
+              </button>
+              <button
+                type="button"
+                onClick={() => setSchoolSignupMode('invite')}
+                className={`px-3 py-1.5 text-sm flex-1 transition-colors ${
+                  schoolSignupMode === 'invite'
+                    ? 'bg-amber-600 text-white'
+                    : 'bg-white text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                Legacy Invite
+              </button>
             </div>
-
-            <div className="space-y-3">
-              <div className="space-y-2">
-                <Label htmlFor="school-email">Contact Email</Label>
-                <div className="flex gap-2">
+            <p className="text-xs text-gray-500">
+              Use a legacy invite code to create a school immediately, or verify by email to request approval.
+            </p>
+          </div>
+          {/* Step 1: Email Verification */}
+          {isInviteMode ? (
+            <div className="space-y-4">
+              <div className="flex items-center gap-2 mb-2">
+                <div className="w-6 h-6 rounded-full flex items-center justify-center text-sm font-bold bg-amber-500 text-white">
+                  1
+                </div>
+                <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                  Invite Details
+                </h3>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2 sm:col-span-2">
+                  <Label htmlFor="school-invite-code">Legacy Invite Code</Label>
                   <Input
-                    id="school-email"
-                    type="email"
-                    placeholder="Enter your email address"
-                    value={schoolEmail}
-                    onChange={handleEmailChange}
-                    disabled={emailVerified}
-                    className={emailVerified ? 'bg-green-50 border-green-300' : ''}
+                    id="school-invite-code"
+                    type="text"
+                    placeholder="Enter the invite code provided"
+                    value={schoolInviteCode}
+                    onChange={(e) => setSchoolInviteCode(e.target.value)}
                   />
+                </div>
+                <div className="space-y-2 sm:col-span-2">
+                  <Label htmlFor="school-invite-id">School ID (optional)</Label>
+                  <Input
+                    id="school-invite-id"
+                    type="text"
+                    placeholder="Enter the school ID if provided"
+                    value={schoolInviteSchoolId}
+                    onChange={(e) => setSchoolInviteSchoolId(e.target.value)}
+                  />
+                  <p className="text-xs text-gray-500">
+                    Use the school ID that came with the invite if you were given one.
+                  </p>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex items-center gap-2 mb-2">
+                <div className={`w-6 h-6 rounded-full flex items-center justify-center text-sm font-bold ${emailVerified ? 'bg-green-500 text-white' : 'bg-amber-500 text-white'}`}>
+                  {emailVerified ? '✓' : '1'}
+                </div>
+                <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                  Verify Your Email
+                </h3>
+              </div>
+
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <Label htmlFor="school-email">Contact Email</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      id="school-email"
+                      type="email"
+                      placeholder="Enter your email address"
+                      value={schoolEmail}
+                      onChange={handleEmailChange}
+                      disabled={emailVerified}
+                      className={emailVerified ? 'bg-green-50 border-green-300' : ''}
+                    />
+                    {!emailVerified && (
+                      <Button
+                        onClick={handleSendVerificationCode}
+                        disabled={verificationLoading || !schoolEmail.trim()}
+                        className="bg-amber-600 hover:bg-amber-700 whitespace-nowrap"
+                      >
+                        {verificationLoading ? 'Sending...' : verificationSent ? 'Resend Code' : 'Send Code'}
+                      </Button>
+                    )}
+                  </div>
+                  {emailVerified && (
+                    <p className="text-xs text-green-600 font-medium">
+                      Email verified successfully!
+                    </p>
+                  )}
                   {!emailVerified && (
-                    <Button
-                      onClick={handleSendVerificationCode}
-                      disabled={verificationLoading || !schoolEmail.trim()}
-                      className="bg-amber-600 hover:bg-amber-700 whitespace-nowrap"
-                    >
-                      {verificationLoading ? 'Sending...' : verificationSent ? 'Resend Code' : 'Send Code'}
-                    </Button>
+                    <p className="text-xs text-gray-500">
+                      We'll send a verification code to this email address.
+                    </p>
                   )}
                 </div>
-                {emailVerified && (
-                  <p className="text-xs text-green-600 font-medium">
-                    Email verified successfully!
-                  </p>
-                )}
-                {!emailVerified && (
-                  <p className="text-xs text-gray-500">
-                    We'll send a verification code to this email address.
-                  </p>
+
+                {verificationSent && !emailVerified && (
+                  <div className="space-y-4 p-4 bg-amber-50 border border-amber-200 rounded-lg">
+                    <Label className="text-center block">Enter Verification Code</Label>
+                    <VerificationCodeInput
+                      value={emailVerificationCode}
+                      onChange={setEmailVerificationCode}
+                      disabled={verificationLoading}
+                    />
+                    <div className="flex justify-center">
+                      <Button
+                        onClick={handleVerifyCode}
+                        disabled={verificationLoading || emailVerificationCode.length !== 6}
+                        className="bg-green-600 hover:bg-green-700 px-8"
+                      >
+                        {verificationLoading ? 'Verifying...' : 'Verify Code'}
+                      </Button>
+                    </div>
+                    <p className="text-xs text-amber-700 text-center">
+                      Check your email for the 6-digit verification code. The code expires in 15 minutes.
+                      <br />
+                      <span className="text-gray-500">Can't find it? Check your junk/spam folder.</span>
+                    </p>
+                  </div>
                 )}
               </div>
-
-              {verificationSent && !emailVerified && (
-                <div className="space-y-4 p-4 bg-amber-50 border border-amber-200 rounded-lg">
-                  <Label className="text-center block">Enter Verification Code</Label>
-                  <VerificationCodeInput
-                    value={emailVerificationCode}
-                    onChange={setEmailVerificationCode}
-                    disabled={verificationLoading}
-                  />
-                  <div className="flex justify-center">
-                    <Button
-                      onClick={handleVerifyCode}
-                      disabled={verificationLoading || emailVerificationCode.length !== 6}
-                      className="bg-green-600 hover:bg-green-700 px-8"
-                    >
-                      {verificationLoading ? 'Verifying...' : 'Verify Code'}
-                    </Button>
-                  </div>
-                  <p className="text-xs text-amber-700 text-center">
-                    Check your email for the 6-digit verification code. The code expires in 15 minutes.
-                    <br />
-                    <span className="text-gray-500">Can't find it? Check your junk/spam folder.</span>
-                  </p>
-                </div>
-              )}
             </div>
-          </div>
+          )}
 
-          {/* Step 2: School Details (only shown after email verification) */}
-          {emailVerified && (
+          {/* Step 2: School Details (shown after email verification or invite selection) */}
+          {(emailVerified || isInviteMode) && (
             <>
               <div className="border-t border-gray-200 pt-4">
                 <div className="flex items-center gap-2 mb-4">
@@ -244,7 +319,7 @@ function SchoolRegistration({ app }) {
             <Button variant="ghost" onClick={handleBackToLogin} className="sm:w-auto w-full">
               Back to Login
             </Button>
-            {emailVerified && (
+            {(emailVerified || isInviteMode) && (
               <Button
                 onClick={handleSubmit}
                 className="bg-amber-600 hover:bg-amber-700 sm:w-auto w-full"

--- a/src/routes/golden_plate_recorder_db/auth_routes.py
+++ b/src/routes/golden_plate_recorder_db/auth_routes.py
@@ -1,10 +1,11 @@
 import os
+import uuid
 
 import requests
 from flask import jsonify, request, session
 
 from . import recorder_bp
-from .db import DEFAULT_SCHOOL_ID, AccountCreationRequest, _now_utc, db_session
+from .db import DEFAULT_SCHOOL_ID, AccountCreationRequest, User, _now_utc, db_session
 from .security import get_current_user, is_guest, require_auth
 from .users import (
     create_user_record,
@@ -149,20 +150,71 @@ def signup():
     password = data.get('password', '').strip()
     name = data.get('name', '').strip()
     school_code = data.get('school_code', '').strip()
+    invite_code = data.get('invite_code', '').strip()
     recaptcha_token = data.get('recaptcha_token', '').strip()
 
     # Verify reCAPTCHA if configured
     if RECAPTCHA_SECRET_KEY and not verify_recaptcha(recaptcha_token):
         return jsonify({'error': 'reCAPTCHA verification failed. Please try again.'}), 400
 
-    if not username or not password or not name or not school_code:
-        return jsonify({'error': 'Username, password, name, and school code are required'}), 400
+    if not username or not password or not name or (not school_code and not invite_code):
+        error_message = 'Username, password, name, and school code are required'
+        if invite_code:
+            error_message = 'Username, password, name, and invite code are required'
+        return jsonify({'error': error_message}), 400
 
     if len(username) < 3:
         return jsonify({'error': 'Username must be at least 3 characters long'}), 400
 
     if len(password) < 6:
         return jsonify({'error': 'Password must be at least 6 characters long'}), 400
+
+    if invite_code:
+        invite = get_invite_code_record(invite_code)
+        if not invite or invite.status != 'unused':
+            return jsonify({'error': 'Invalid invite code'}), 403
+
+        school = get_school_by_id(invite.school_id)
+        if not school:
+            return jsonify({'error': 'Invite code is not tied to an active school'}), 404
+
+        if school.status != 'active':
+            return jsonify({'error': 'This school is not accepting new registrations'}), 403
+
+        if get_user_by_username(username, school_id=invite.school_id):
+            return jsonify({'error': 'Username already exists in this school'}), 409
+
+        if get_user_by_username(username):
+            return jsonify({'error': 'Username already exists'}), 409
+
+        try:
+            user = User(
+                id=str(uuid.uuid4()),
+                school_id=invite.school_id,
+                username=username,
+                password_hash=password,
+                display_name=name,
+                role=invite.role or 'user',
+                status='active',
+                created_at=_now_utc(),
+                updated_at=_now_utc(),
+            )
+            db_session.add(user)
+            invite.status = 'used'
+            invite.user_id = user.id
+            invite.used_by = user.id
+            invite.used_at = _now_utc()
+            invite.school_id = user.school_id
+            invite.updated_at = _now_utc()
+            db_session.commit()
+        except Exception:
+            db_session.rollback()
+            return jsonify({'error': 'Could not create account with invite code'}), 500
+
+        return jsonify({
+            'status': 'success',
+            'message': 'Account created successfully.'
+        }), 201
 
     # Find the school by slug (school code)
     school = get_school_by_slug(school_code)


### PR DESCRIPTION
### Motivation
- Preserve support for legacy one-time invite codes so users and schools can sign up immediately using existing invite records. 
- Expose the legacy invite option in the UI for both user sign-up and school registration while keeping the existing request/verification flows. 
- Make house ranking default to a count-based sort and place the Count button to the left for quicker access.

### Description
- Backend: `auth_routes.signup` now accepts `invite_code` and will create the user immediately using the invite (marks invite as used); existing school-code request flow remains intact. 
- Backend: `interschool_routes.register_school` now accepts `invite_code` (and optional `school_id`) and can create the school + admin user immediately when a valid unused invite is provided, otherwise falls back to the email/verification request path. 
- Frontend: added legacy-invite UI and state to the signup dialog and school registration view, new state fields in `usePlateApp.js`, and updated `signup`/`registerSchool` payloads to include `invite_code` when using invite mode. 
- UI: default house ranking sort changed to `count` in `usePlateApp.js`, and the sort buttons were reordered in `MainPortal.jsx` so Count appears on the left.

### Testing
- Installed frontend deps with `pnpm install` and started the dev server with `pnpm dev`, which launched successfully. 
- Ran an automated Playwright UI script that opened the app, opened the signup dialog and the school registration screen, and produced screenshots at `artifacts/signup-dialog.png` and `artifacts/school-registration.png`, confirming the new UI flows rendered (script completed with screenshots). 
- No unit or integration test suites were executed for backend logic in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967e12a5dc883208253eb3de22a650c)