### PR TITLE
Update verification code expiry tip to 5 minutes

### DIFF
--- a/frontend/src/components/SchoolRegistration.jsx
+++ b/frontend/src/components/SchoolRegistration.jsx
@@ -35,6 +35,7 @@ function SchoolRegistration({ app }) {
     verificationLoading,
     sendVerificationCode,
     verifyEmailCode,
+    verificationExpiryMinutes,
     registerSchool,
     isLoading,
     setShowSchoolRegistration,
@@ -212,7 +213,7 @@ function SchoolRegistration({ app }) {
                       </Button>
                     </div>
                     <p className="text-xs text-amber-700 text-center">
-                      Check your email for the 6-digit verification code. The code expires in 15 minutes.
+                      Check your email for the 6-digit verification code. The code expires in {verificationExpiryMinutes} minutes.
                       <br />
                       <span className="text-gray-500">Can't find it? Check your junk/spam folder.</span>
                     </p>

--- a/frontend/src/hooks/usePlateApp.js
+++ b/frontend/src/hooks/usePlateApp.js
@@ -31,6 +31,7 @@ export function usePlateApp() {
   const [emailVerified, setEmailVerified] = useState(false)
   const [verificationSent, setVerificationSent] = useState(false)
   const [verificationLoading, setVerificationLoading] = useState(false)
+  const [verificationExpiryMinutes, setVerificationExpiryMinutes] = useState(5)
   const [guestSchoolCode, setGuestSchoolCode] = useState('')
   const [showGuestSchoolDialog, setShowGuestSchoolDialog] = useState(false)
   
@@ -341,6 +342,9 @@ export function usePlateApp() {
 
       if (response.ok) {
         setVerificationSent(true)
+        if (data.expiry_minutes) {
+          setVerificationExpiryMinutes(data.expiry_minutes)
+        }
         showMessage('Verification code sent to your email!', 'success')
         return true
       } else {
@@ -2270,6 +2274,7 @@ export function usePlateApp() {
     verificationSent,
     setVerificationSent,
     verificationLoading,
+    verificationExpiryMinutes,
     sendVerificationCode,
     verifyEmailCode,
     sessionId,

--- a/src/routes/golden_plate_recorder_db/interschool_routes.py
+++ b/src/routes/golden_plate_recorder_db/interschool_routes.py
@@ -19,6 +19,7 @@ from .db import (
 )
 from .email_service import (
     create_verification_code,
+    VERIFICATION_CODE_EXPIRY_MINUTES,
     is_email_verified,
     send_verification_email,
     verify_code as verify_email_code,
@@ -173,6 +174,7 @@ def send_verification_code():
         return jsonify({
             'status': 'success',
             'message': 'Verification code sent to your email address.',
+            'expiry_minutes': VERIFICATION_CODE_EXPIRY_MINUTES,
         }), 200
 
     except Exception as e:


### PR DESCRIPTION
The tip now displays the actual expiry time (5 minutes) fetched from the backend API instead of a hardcoded 15-minute value.